### PR TITLE
fixed bug with checkSolved()

### DIFF
--- a/app/src/main/java/com/example/se2_gruppenphase_ss21/game/Tiles.java
+++ b/app/src/main/java/com/example/se2_gruppenphase_ss21/game/Tiles.java
@@ -528,7 +528,6 @@ public class Tiles extends AppCompatActivity implements InRoundListener,
     }
 
     private void detatchfromtilearray(){
-        Tile empty = new Tile();
         for(Position positions:currenttile.getShape()){
             tilearray[currentpositiony+positions.getY()][currentpositionx+positions.getX()] = empty;
         }


### PR DESCRIPTION
a different instance of empty was passed instead of the same global one used to check if there's an empty field